### PR TITLE
Support inet6 on Debian platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Attributes
 * source (default: 'ifcfg.erb') - Template file to use for interface config
 
 #### Debian Only Attributes
+* ipv6 (true/false) - Wether this is an inet or inet6 network interface.
 * bridge_stp (true/false) - Wether to enable/disable bridge STP.  Applies to debian only.
 * bridge_ports - Array of interfaces to add to defined bridge
 * metric -

--- a/libraries/provider_debian_network_interface.rb
+++ b/libraries/provider_debian_network_interface.rb
@@ -73,6 +73,7 @@ class Chef
             mode 0644
             variables device: new_resource.device,
                       type: new_resource.type,
+                      ipv6: new_resource.ipv6,
                       auto: new_resource.onboot,
                       address: new_resource.address,
                       netmask: new_resource.netmask,

--- a/libraries/provider_debian_network_interface.rb
+++ b/libraries/provider_debian_network_interface.rb
@@ -65,7 +65,7 @@ class Chef
           package 'bridge-utils' do
             not_if { new_resource.bridge_ports.nil? }
           end
-          
+
           if new_resource.ipv6
             network_type = 'inet6'
           else

--- a/libraries/provider_debian_network_interface.rb
+++ b/libraries/provider_debian_network_interface.rb
@@ -65,6 +65,12 @@ class Chef
           package 'bridge-utils' do
             not_if { new_resource.bridge_ports.nil? }
           end
+          
+          if new_resource.ipv6
+            network_type = 'inet6'
+          else
+            network_type = 'inet'
+          end
 
           # Dump config for the interface
           template "/etc/network/interfaces.d/#{new_resource.device}" do
@@ -73,7 +79,7 @@ class Chef
             mode 0644
             variables device: new_resource.device,
                       type: new_resource.type,
-                      ipv6: new_resource.ipv6,
+                      network_type: network_type,
                       auto: new_resource.onboot,
                       address: new_resource.address,
                       netmask: new_resource.netmask,

--- a/libraries/resource_debian_network_interface.rb
+++ b/libraries/resource_debian_network_interface.rb
@@ -43,7 +43,7 @@ class Chef
         def bridge_ports(arg = nil)
           set_or_return(:bridge_ports, arg, kind_of: Array)
         end
-        
+
         def ipv6(arg = nil)
           set_or_return(:ipv6, arg, kind_of: [TrueClass, FalseClass])
         end

--- a/libraries/resource_debian_network_interface.rb
+++ b/libraries/resource_debian_network_interface.rb
@@ -45,7 +45,7 @@ class Chef
         end
         
         def ipv6(arg = nil)
-          set_or_return(:ipv6, arg, kind_of: Boolean)
+          set_or_return(:ipv6, arg, kind_of: [TrueClass, FalseClass])
         end
 
         def metric(arg = nil)

--- a/libraries/resource_debian_network_interface.rb
+++ b/libraries/resource_debian_network_interface.rb
@@ -43,6 +43,10 @@ class Chef
         def bridge_ports(arg = nil)
           set_or_return(:bridge_ports, arg, kind_of: Array)
         end
+        
+        def ipv6(arg = nil)
+          set_or_return(:ipv6, arg, kind_of: Boolean)
+        end
 
         def metric(arg = nil)
           set_or_return(:metric, arg, kind_of: Integer)

--- a/templates/default/debian_interface.erb
+++ b/templates/default/debian_interface.erb
@@ -3,7 +3,7 @@
 <% if @auto -%>
 auto <%= @device %>
 <% end %>
-iface <%= @device %> inet <%= @type %>
+iface <%= @device %> <%= @network_type %> <%= @type %>
 <% if @address -%>
   address <%= @address %>
 <% end %>


### PR DESCRIPTION
Related to #18 this is my stab at implementing an 'ipv6' option in the resource to switch the network interface from 'inet' to 'inet6'. Only thing missing here is adding the appropriate tests to try an ipv6 network configuration in testing, though I could try to cover it via unit tests instead if that would be preferred.