### PR TITLE
Feature/rhel arpcheck hotplug

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Attributes
 * ovs_bridge - OVS Bridge to bind ovs port to (primarily used when `type` is set as 'OVSPort')
 * dns_domain - DNS domain
 * zone - FirewallD zone
+* arpcheck - Whether to arping before bringing up an ethernet device to check for an IP conflict (default: true)
+* hotplug - Activate devices on hotplug (default: true)
 
 #### Windows Only Attributes
 * hw_address - Can be used to define what device to manage

--- a/libraries/provider_rhel_network_interface.rb
+++ b/libraries/provider_rhel_network_interface.rb
@@ -74,7 +74,9 @@ class Chef
                       dns: new_resource.dns,
                       prefix: new_resource.prefix,
                       domain: new_resource.dns_domain,
-                      zone: new_resource.zone
+                      zone: new_resource.zone,
+                      arpcheck: new_resource.arpcheck,
+                      hotplug: new_resource.hotplug
             notifies :run, "execute[reload interface #{new_resource.device}]", new_resource.reload_type if new_resource.reload
             notifies :run, "execute[post up command for #{new_resource.device}]", :immediately unless new_resource.post_up.nil?
           end

--- a/libraries/resource_rhel_network_interface.rb
+++ b/libraries/resource_rhel_network_interface.rb
@@ -109,7 +109,7 @@ class Chef
         end
 
         def hotplug(arg = nil)
-          set_or_return(:zone, arg, kind_of: [TrueClass, FalseClass])
+          set_or_return(:hotplug, arg, kind_of: [TrueClass, FalseClass])
         end
       end
     end

--- a/libraries/resource_rhel_network_interface.rb
+++ b/libraries/resource_rhel_network_interface.rb
@@ -103,6 +103,14 @@ class Chef
         def zone(arg = nil)
           set_or_return(:zone, arg, kind_of: String)
         end
+
+        def arpcheck(arg = nil)
+          set_or_return(:arpcheck, arg, kind_of: [TrueClass, FalseClass])
+        end
+
+        def hotplug(arg = nil)
+          set_or_return(:zone, arg, kind_of: [TrueClass, FalseClass])
+        end
       end
     end
   end

--- a/spec/helper_recipes/fake_core_spec.rb
+++ b/spec/helper_recipes/fake_core_spec.rb
@@ -113,6 +113,8 @@ GATEWAY="10.0.0.1"
 NM_CONTROLLED="no"
 DEVICETYPE="ovs"
 ZONE="trusted"
+ARPCHECK="yes"
+HOTPLUG="no"
 '
     end
 

--- a/templates/default/ifcfg.erb
+++ b/templates/default/ifcfg.erb
@@ -78,3 +78,9 @@ DOMAIN="<%=@domain%>"
 <% unless @zone.nil? -%>
 ZONE="<%= @zone %>"
 <% end %>
+<% unless @arpcheck.nil? -%>
+ARPCHECK="<%= @arpcheck ? 'yes' : 'no' %>"
+<% end %>
+<% unless @hotplug.nil? -%>
+HOTPLUG="<%= @hotplug ? 'yes' : 'no' %>"
+<% end %>

--- a/test/fixtures/cookbooks/fake/recipes/_core_rhel.rb
+++ b/test/fixtures/cookbooks/fake/recipes/_core_rhel.rb
@@ -14,4 +14,6 @@ network_interface 'enp0s4' do
   devicetype 'ovs'
   post_up 'sleep 1'
   zone 'trusted'
+  arpcheck true
+  hotplug false
 end


### PR DESCRIPTION
Add two more things to RHEL - hotplug and arpcheck. The former controls whether to activate a device when it's hot plugged (defaults to true) and the latter lets you turn off the arping the ifcfg-eth script does to see if something else is using that address.