### PR TITLE
Feature/rhel ovs dhcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Attributes
 * zone - FirewallD zone
 * arpcheck - Whether to arping before bringing up an ethernet device to check for an IP conflict (default: true)
 * hotplug - Activate devices on hotplug (default: true)
+* ovsbootproto - Set to 'dhcp' if you want to use DHCP on an OVSBridge
+* ovsdhcpinterfaces - List of physical devices to use for DHCP on an OVSBridge
 
 #### Windows Only Attributes
 * hw_address - Can be used to define what device to manage

--- a/libraries/provider_rhel_network_interface.rb
+++ b/libraries/provider_rhel_network_interface.rb
@@ -77,7 +77,9 @@ class Chef
                       zone: new_resource.zone,
                       arpcheck: new_resource.arpcheck,
                       hotplug: new_resource.hotplug,
-                      metric: new_resource.metric
+                      metric: new_resource.metric,
+                      ovsbootproto: new_resource.ovsbootproto,
+                      ovsdhcpinterfaces: new_resource.ovsdhcpinterfaces
             notifies :run, "execute[reload interface #{new_resource.device}]", new_resource.reload_type if new_resource.reload
             notifies :run, "execute[post up command for #{new_resource.device}]", :immediately unless new_resource.post_up.nil?
           end

--- a/libraries/resource_rhel_network_interface.rb
+++ b/libraries/resource_rhel_network_interface.rb
@@ -115,6 +115,14 @@ class Chef
         def metric(arg = nil)
           set_or_return(:metric, arg, kind_of: Integer)
         end
+
+        def ovsbootproto(arg = nil)
+          set_or_return(:ovsbootproto, arg, kind_of: String)
+        end
+
+        def ovsdhcpinterfaces(arg = nil)
+          set_or_return(:ovsdhcpinterfaces, arg, kind_of: [String, Array])
+        end
       end
     end
   end

--- a/spec/helper_recipes/fake_ovs_dhcp_spec.rb
+++ b/spec/helper_recipes/fake_ovs_dhcp_spec.rb
@@ -1,0 +1,357 @@
+require 'spec_helper'
+
+describe 'fake::ovs_dhcp' do
+  context 'when platform_family rhel 6.x' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: ['rhel_network_interface', 'network_interface']).converge(described_recipe)
+    end
+
+    let(:default_ovsbr0_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="ovsbr0"
+TYPE="OVSBridge"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+USERCTL="no"
+DEVICETYPE="ovs"
+ARPCHECK="no"
+HOTPLUG="no"
+OVSBOOTPROTO="dhcp"
+OVSDHCPINTERFACES="eth5"
+'
+    end
+
+    let(:default_eth5_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="eth5"
+TYPE="OVSPort"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+DEVICETYPE="ovs"
+OVS_BRIDGE="ovsbr0"
+'
+    end
+
+    let(:default_ovsbr1_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="ovsbr1"
+TYPE="OVSBridge"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+USERCTL="no"
+DEVICETYPE="ovs"
+ARPCHECK="no"
+HOTPLUG="no"
+OVSBOOTPROTO="dhcp"
+OVSDHCPINTERFACES="eth6"
+'
+    end
+
+    let(:default_eth6_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="eth6"
+TYPE="OVSPort"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+DEVICETYPE="ovs"
+OVS_BRIDGE="ovsbr1"
+'
+    end
+
+    it 'does not install any extra packages' do
+      expect(chef_run).not_to install_package 'vconfig'
+      expect(chef_run).not_to install_package 'iputils'
+      expect(chef_run).not_to install_package 'bridge-utils'
+    end
+
+    context 'for interface ovsbr0 definition' do
+      it 'creates the bridge' do
+        expect(chef_run).to create_network_interface 'ovsbr0'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr0'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr0').with_content(default_ovsbr0_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface ovsbr0')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).to notify('execute[reload interface ovsbr0]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for ovsbr0')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).not_to notify('execute[post up command for ovsbr0]').to(:run).immediately
+      end
+    end
+
+    context 'for interface eth5 definition' do
+      it 'adds the device to the bridge' do
+        expect(chef_run).to create_network_interface 'eth5'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-eth5'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-eth5').with_content(default_eth5_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface eth5')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth5')
+        expect(resource).to notify('execute[reload interface eth5]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for eth5')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth5')
+        expect(resource).not_to notify('execute[post up command for eth5]').to(:run).immediately
+      end
+    end
+
+    context 'for interface ovsbr1 definition' do
+      it 'creates the bridge' do
+        expect(chef_run).to create_network_interface 'ovsbr1'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr1'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr1').with_content(default_ovsbr1_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface ovsbr1')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).to notify('execute[reload interface ovsbr1]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for ovsbr1')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).not_to notify('execute[post up command for ovsbr1]').to(:run).immediately
+      end
+    end
+
+    context 'for interface eth6 definition' do
+      it 'adds the device to the bridge' do
+        expect(chef_run).to create_network_interface 'eth6'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-eth6'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-eth6').with_content(default_eth6_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface eth6')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth6')
+        expect(resource).to notify('execute[reload interface eth6]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for eth6')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth6')
+        expect(resource).not_to notify('execute[post up command for eth6]').to(:run).immediately
+      end
+    end
+  end
+
+  context 'when platform_family rhel 7.x' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0', step_into: ['rhel_network_interface', 'network_interface']).converge(described_recipe)
+    end
+
+    let(:default_ovsbr0_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="ovsbr0"
+TYPE="OVSBridge"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+USERCTL="no"
+DEVICETYPE="ovs"
+ARPCHECK="no"
+HOTPLUG="no"
+OVSBOOTPROTO="dhcp"
+OVSDHCPINTERFACES="enp0s5"
+'
+    end
+
+    let(:default_enp0s5_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="enp0s5"
+TYPE="OVSPort"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+DEVICETYPE="ovs"
+OVS_BRIDGE="ovsbr0"
+'
+    end
+    let(:default_ovsbr1_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="ovsbr1"
+TYPE="OVSBridge"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+USERCTL="no"
+DEVICETYPE="ovs"
+ARPCHECK="no"
+HOTPLUG="no"
+OVSBOOTPROTO="dhcp"
+OVSDHCPINTERFACES="enp0s6"
+'
+    end
+
+    let(:default_enp0s6_config_contents) do
+      '# This file maintained by Chef.  DO NOT EDIT!
+
+DEVICE="enp0s6"
+TYPE="OVSPort"
+ONBOOT="yes"
+BOOTPROTO="none"
+NM_CONTROLLED="no"
+IPV6INIT="no"
+DEVICETYPE="ovs"
+OVS_BRIDGE="ovsbr1"
+'
+    end
+
+    context 'for interface ovsbr0 definition' do
+      it 'creates the bridge' do
+        expect(chef_run).to create_network_interface 'ovsbr0'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr0'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr0').with_content(default_ovsbr0_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface ovsbr0')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).to notify('execute[reload interface ovsbr0]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for ovsbr0')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).not_to notify('execute[post up command for ovsbr0]').to(:run).immediately
+      end
+    end
+
+    context 'for interface enp0s5 definition' do
+      it 'adds the device to the bridge' do
+        expect(chef_run).to create_network_interface 'enp0s5'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-enp0s5'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-enp0s5').with_content(default_enp0s5_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface enp0s5')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s5')
+        expect(resource).to notify('execute[reload interface enp0s5]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for enp0s5')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s5')
+        expect(resource).not_to notify('execute[post up command for enp0s5]').to(:run).immediately
+      end
+    end
+
+    context 'for interface ovsbr1 definition' do
+      it 'creates the bridge' do
+        expect(chef_run).to create_network_interface 'ovsbr1'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr1'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr1').with_content(default_ovsbr1_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface ovsbr1')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).to notify('execute[reload interface ovsbr1]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for ovsbr1')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).not_to notify('execute[post up command for ovsbr1]').to(:run).immediately
+      end
+    end
+
+    context 'for interface enp0s6 definition' do
+      it 'adds the device to the bridge' do
+        expect(chef_run).to create_network_interface 'enp0s6'
+        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-enp0s6'
+        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-enp0s6').with_content(default_enp0s6_config_contents)
+      end
+
+      it 'does not reload interface by default' do
+        expect(chef_run).not_to run_execute('reload interface enp0s6')
+      end
+
+      it 'it reloads the interface after updating the config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s6')
+        expect(resource).to notify('execute[reload interface enp0s6]').to(:run).immediately
+      end
+
+      it 'does not run post up by default' do
+        expect(chef_run).not_to run_execute('post up command for enp0s6')
+      end
+
+      it 'does not run post up command after updating config' do
+        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s6')
+        expect(resource).not_to notify('execute[post up command for enp0s6]').to(:run).immediately
+      end
+    end
+  end
+
+end

--- a/spec/helper_recipes/fake_ovs_dhcp_spec.rb
+++ b/spec/helper_recipes/fake_ovs_dhcp_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 describe 'fake::ovs_dhcp' do
   context 'when platform_family rhel 6.x' do
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: ['rhel_network_interface', 'network_interface']).converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5',
+                               step_into: ['rhel_network_interface',
+                                           'network_interface'])
+                          .converge(described_recipe)
     end
 
     let(:default_ovsbr0_config_contents) do
@@ -79,8 +82,11 @@ OVS_BRIDGE="ovsbr1"
     context 'for interface ovsbr0 definition' do
       it 'creates the bridge' do
         expect(chef_run).to create_network_interface 'ovsbr0'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr0'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr0').with_content(default_ovsbr0_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+          .with_content(default_ovsbr0_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -88,8 +94,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
-        expect(resource).to notify('execute[reload interface ovsbr0]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).to notify('execute[reload interface ovsbr0]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -97,16 +105,21 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
-        expect(resource).not_to notify('execute[post up command for ovsbr0]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).not_to notify('execute[post up command for ovsbr0]')
+          .to(:run).immediately
       end
     end
 
     context 'for interface eth5 definition' do
       it 'adds the device to the bridge' do
         expect(chef_run).to create_network_interface 'eth5'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-eth5'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-eth5').with_content(default_eth5_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-eth5')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-eth5')
+          .with_content(default_eth5_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -114,8 +127,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth5')
-        expect(resource).to notify('execute[reload interface eth5]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-eth5')
+        expect(resource).to notify('execute[reload interface eth5]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -123,16 +138,21 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth5')
-        expect(resource).not_to notify('execute[post up command for eth5]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-eth5')
+        expect(resource).not_to notify('execute[post up command for eth5]')
+          .to(:run).immediately
       end
     end
 
     context 'for interface ovsbr1 definition' do
       it 'creates the bridge' do
         expect(chef_run).to create_network_interface 'ovsbr1'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr1'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr1').with_content(default_ovsbr1_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+          .with_content(default_ovsbr1_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -140,8 +160,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
-        expect(resource).to notify('execute[reload interface ovsbr1]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).to notify('execute[reload interface ovsbr1]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -149,16 +171,21 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
-        expect(resource).not_to notify('execute[post up command for ovsbr1]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).not_to notify('execute[post up command for ovsbr1]')
+          .to(:run).immediately
       end
     end
 
     context 'for interface eth6 definition' do
       it 'adds the device to the bridge' do
         expect(chef_run).to create_network_interface 'eth6'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-eth6'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-eth6').with_content(default_eth6_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-eth6')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-eth6')
+          .with_content(default_eth6_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -166,8 +193,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth6')
-        expect(resource).to notify('execute[reload interface eth6]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-eth6')
+        expect(resource).to notify('execute[reload interface eth6]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -175,15 +204,20 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-eth6')
-        expect(resource).not_to notify('execute[post up command for eth6]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-eth6')
+        expect(resource).not_to notify('execute[post up command for eth6]')
+          .to(:run).immediately
       end
     end
   end
 
   context 'when platform_family rhel 7.x' do
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0', step_into: ['rhel_network_interface', 'network_interface']).converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0',
+                               step_into: ['rhel_network_interface',
+                                           'network_interface'])
+                          .converge(described_recipe)
     end
 
     let(:default_ovsbr0_config_contents) do
@@ -252,8 +286,11 @@ OVS_BRIDGE="ovsbr1"
     context 'for interface ovsbr0 definition' do
       it 'creates the bridge' do
         expect(chef_run).to create_network_interface 'ovsbr0'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr0'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr0').with_content(default_ovsbr0_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+          .with_content(default_ovsbr0_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -261,8 +298,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
-        expect(resource).to notify('execute[reload interface ovsbr0]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).to notify('execute[reload interface ovsbr0]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -270,16 +309,21 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
-        expect(resource).not_to notify('execute[post up command for ovsbr0]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr0')
+        expect(resource).not_to notify('execute[post up command for ovsbr0]')
+          .to(:run).immediately
       end
     end
 
     context 'for interface enp0s5 definition' do
       it 'adds the device to the bridge' do
         expect(chef_run).to create_network_interface 'enp0s5'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-enp0s5'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-enp0s5').with_content(default_enp0s5_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s5')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s5')
+          .with_content(default_enp0s5_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -287,8 +331,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s5')
-        expect(resource).to notify('execute[reload interface enp0s5]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s5')
+        expect(resource).to notify('execute[reload interface enp0s5]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -296,16 +342,21 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s5')
-        expect(resource).not_to notify('execute[post up command for enp0s5]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s5')
+        expect(resource).not_to notify('execute[post up command for enp0s5]')
+          .to(:run).immediately
       end
     end
 
     context 'for interface ovsbr1 definition' do
       it 'creates the bridge' do
         expect(chef_run).to create_network_interface 'ovsbr1'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-ovsbr1'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-ovsbr1').with_content(default_ovsbr1_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+          .with_content(default_ovsbr1_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -313,8 +364,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
-        expect(resource).to notify('execute[reload interface ovsbr1]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).to notify('execute[reload interface ovsbr1]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -322,16 +375,21 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
-        expect(resource).not_to notify('execute[post up command for ovsbr1]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-ovsbr1')
+        expect(resource).not_to notify('execute[post up command for ovsbr1]')
+          .to(:run).immediately
       end
     end
 
     context 'for interface enp0s6 definition' do
       it 'adds the device to the bridge' do
         expect(chef_run).to create_network_interface 'enp0s6'
-        expect(chef_run).to create_template '/etc/sysconfig/network-scripts/ifcfg-enp0s6'
-        expect(chef_run).to render_file('/etc/sysconfig/network-scripts/ifcfg-enp0s6').with_content(default_enp0s6_config_contents)
+        expect(chef_run).to create_template(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s6')
+        expect(chef_run).to render_file(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s6')
+          .with_content(default_enp0s6_config_contents)
       end
 
       it 'does not reload interface by default' do
@@ -339,8 +397,10 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'it reloads the interface after updating the config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s6')
-        expect(resource).to notify('execute[reload interface enp0s6]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s6')
+        expect(resource).to notify('execute[reload interface enp0s6]')
+          .to(:run).immediately
       end
 
       it 'does not run post up by default' do
@@ -348,10 +408,11 @@ OVS_BRIDGE="ovsbr1"
       end
 
       it 'does not run post up command after updating config' do
-        resource = chef_run.template('/etc/sysconfig/network-scripts/ifcfg-enp0s6')
-        expect(resource).not_to notify('execute[post up command for enp0s6]').to(:run).immediately
+        resource = chef_run.template(
+          '/etc/sysconfig/network-scripts/ifcfg-enp0s6')
+        expect(resource).not_to notify('execute[post up command for enp0s6]')
+          .to(:run).immediately
       end
     end
   end
-
 end

--- a/templates/default/ifcfg.erb
+++ b/templates/default/ifcfg.erb
@@ -87,3 +87,13 @@ HOTPLUG="<%= @hotplug ? 'yes' : 'no' %>"
 <% if @metric -%>
 METRIC=<%= @metric %>
 <% end %>
+<% if @ovsbootproto -%>
+OVSBOOTPROTO="<%= @ovsbootproto %>"
+<% end -%>
+<% if @ovsdhcpinterfaces -%>
+  <% if @ovsdhcpinterfaces.is_a?(Array) -%>
+OVSDHCPINTERFACES="<%= @ovsdhcpinterfaces.join(' ') %>"
+  <% else -%>
+OVSDHCPINTERFACES="<%= @ovsdhcpinterfaces %>"
+  <% end -%>
+<% end -%>

--- a/test/fixtures/cookbooks/fake/recipes/_ovs_dhcp_enp.rb
+++ b/test/fixtures/cookbooks/fake/recipes/_ovs_dhcp_enp.rb
@@ -1,0 +1,39 @@
+network_interface 'ovsbr0' do
+  bootproto 'none'
+  devicetype 'ovs'
+  hotplug false
+  arpcheck false
+  ipv6init false
+  nm_controlled false
+  ovsdhcpinterfaces ['enp0s5']
+  ovsbootproto 'dhcp'
+  type 'OVSBridge'
+  userctl false
+end
+network_interface 'enp0s5' do
+  bootproto 'none'
+  type 'OVSPort'
+  ipv6init false
+  devicetype 'ovs'
+  ovs_bridge 'ovsbr0'
+end
+# interfaces as string, not array of string
+network_interface 'ovsbr1' do
+  bootproto 'none'
+  devicetype 'ovs'
+  hotplug false
+  arpcheck false
+  ipv6init false
+  nm_controlled false
+  ovsdhcpinterfaces 'enp0s6'
+  ovsbootproto 'dhcp'
+  type 'OVSBridge'
+  userctl false
+end
+network_interface 'enp0s6' do
+  bootproto 'none'
+  type 'OVSPort'
+  ipv6init false
+  devicetype 'ovs'
+  ovs_bridge 'ovsbr1'
+end

--- a/test/fixtures/cookbooks/fake/recipes/_ovs_dhcp_eth.rb
+++ b/test/fixtures/cookbooks/fake/recipes/_ovs_dhcp_eth.rb
@@ -1,0 +1,39 @@
+network_interface 'ovsbr0' do
+  bootproto 'none'
+  devicetype 'ovs'
+  hotplug false
+  arpcheck false
+  ipv6init false
+  nm_controlled false
+  ovsdhcpinterfaces ['eth5']
+  ovsbootproto 'dhcp'
+  type 'OVSBridge'
+  userctl false
+end
+network_interface 'eth5' do
+  bootproto 'none'
+  type 'OVSPort'
+  ipv6init false
+  devicetype 'ovs'
+  ovs_bridge 'ovsbr0'
+end
+# as String, not Array of String
+network_interface 'ovsbr1' do
+  bootproto 'none'
+  devicetype 'ovs'
+  hotplug false
+  arpcheck false
+  ipv6init false
+  nm_controlled false
+  ovsdhcpinterfaces 'eth6'
+  ovsbootproto 'dhcp'
+  type 'OVSBridge'
+  userctl false
+end
+network_interface 'eth6' do
+  bootproto 'none'
+  type 'OVSPort'
+  ipv6init false
+  devicetype 'ovs'
+  ovs_bridge 'ovsbr1'
+end

--- a/test/fixtures/cookbooks/fake/recipes/ovs_dhcp.rb
+++ b/test/fixtures/cookbooks/fake/recipes/ovs_dhcp.rb
@@ -1,0 +1,7 @@
+if %(rhel fedora).include? node['platform_family']
+  if node['platform_version'].to_i <= 6
+    include_recipe 'fake::_ovs_dhcp_eth'
+  else
+    include_recipe 'fake::_ovs_dhcp_enp'
+  end
+end


### PR DESCRIPTION
When using Open vSwitch on RHEL, if you want an OVS bridge to get an IP from DHCP you have to use special config keys called OVSBOOTPROTO and OVSDHCPINTERFACES. This adds support for those keys.