### PR TITLE
Debian: Support multiple interface commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Attributes
  * debian - VLAN device interface
  * RHEL - true/false if device defined is a VLAN interface
  * Win - Integer VlanID to tag to defined device
-* post_up - Post up command to run after modifying the interface
+* post_up - Post up command(s) to run after modifying the interface
 * reload (default: true) - Wether or not to reload the device on config changes
 * reload_type (default: :immediately) - When to reload device on config changes
 * cookbook (default: 'network_interfaces_v2') - Cookbook to look for template files in
@@ -68,12 +68,12 @@ Attributes
 * bridge_ports - Array of interfaces to add to defined bridge
 * metric -
 * bond_slaves - Array of interfaces to add to defined bond
-* pre_up (default: 'sleep 2')- Pre up command
-* up - Up command
-* post_up - Post up command
-* pre_down - Pre down command
-* down - Down command
-* post_down - Post down command
+* pre_up (default: 'sleep 2')- Pre up command(s)
+* up - Up command(s)
+* post_up - Post up command(s)
+* pre_down - Pre down command(s)
+* down - Down command(s)
+* post_down - Post down command(s)
 * custom - Hash of extra attributes to put in device config
 
 #### RHEL Only Attributes

--- a/libraries/resource_debian_network_interface.rb
+++ b/libraries/resource_debian_network_interface.rb
@@ -75,27 +75,27 @@ class Chef
           @pre_up = nil if arg.nil? || arg == ''
           arg = nil if arg == 'NOVAL'
 
-          set_or_return(:pre_up, arg, kind_of: String)
+          set_or_return(:pre_up, arg, kind_of: [String, Array])
         end
 
         def up(arg = nil)
-          set_or_return(:up, arg, kind_of: String)
+          set_or_return(:up, arg, kind_of: [String, Array])
         end
 
         def pre_down(arg = nil)
-          set_or_return(:pre_down, arg, kind_of: String)
+          set_or_return(:pre_down, arg, kind_of: [String, Array])
         end
 
         def down(arg = nil)
-          set_or_return(:down, arg, kind_of: String)
+          set_or_return(:down, arg, kind_of: [String, Array])
         end
 
         def post_down(arg = nil)
-          set_or_return(:post_down, arg, kind_of: String)
+          set_or_return(:post_down, arg, kind_of: [String, Array])
         end
 
         def custom(arg = nil)
-          set_or_return(:custom, arg, kind_of: Hash)
+          set_or_return(:custom, arg, kind_of: [Hash, Array])
         end
       end
     end

--- a/libraries/resource_network_interface.rb
+++ b/libraries/resource_network_interface.rb
@@ -117,7 +117,7 @@ class Chef
       end
 
       def post_up(arg = nil)
-        set_or_return(:post_up, arg, kind_of: String)
+        set_or_return(:post_up, arg, kind_of: [String, Array])
       end
     end
   end

--- a/spec/helper_recipes/fake_override_spec.rb
+++ b/spec/helper_recipes/fake_override_spec.rb
@@ -136,7 +136,9 @@ describe 'fake::override' do
     end
 
     it 'properly sets pre_up attribtue in config' do
-      expect(chef_run).to render_file('/etc/network/interfaces.d/eth2').with_content('  pre-up pre up code')
+      expect(chef_run).to render_file('/etc/network/interfaces.d/eth2')
+        .with_content('  pre-up 1st pre up code')
+        .with_content('  pre-up 2nd pre up code')
     end
 
     it 'properly sets up attribtue in config' do

--- a/templates/default/debian_interface.erb
+++ b/templates/default/debian_interface.erb
@@ -46,24 +46,18 @@ iface <%= @device %> <%= @network_type %> <%= @type %>
 <% if @mtu -%>
   mtu <%= @mtu %>
 <% end %>
-<% if @pre_up -%>
-  pre-up <%= @pre_up %>
-<% end %>
-<% if @up -%>
-  up <%= @up %>
-<% end %>
-<% if @post_up -%>
-  post-up <%= @post_up %>
-<% end %>
-<% if @pre_down -%>
-  pre-down <%= @pre_down %>
-<% end %>
-<% if @down -%>
-  down <%= @down %>
-<% end %>
-<% if @post_down -%>
-  post-down <%= @post_down %>
-<% end %>
+<% # Command block, order matters, so do not use a hash
+[
+  ['pre-up', @pre_up],
+  ['up', @up],
+  ['post-up', @post_up],
+  ['pre-down', @pre_down],
+  ['down', @down],
+  ['post-down', @post_down],
+].each { |c| Array(c[1]).each { |v| -%>
+  <%= c[0] %> <%= v %>
+<% } %>
+<% } %>
 <% if @custom -%>
 <% @custom.sort_by{ |instruc, command| instruc }.each do |instruc, command| -%>
   <%= instruc %> <%= command %>

--- a/test/fixtures/cookbooks/fake/recipes/override.rb
+++ b/test/fixtures/cookbooks/fake/recipes/override.rb
@@ -35,7 +35,7 @@ when 'debian'
     bridge_ports ['eth3', 'eth4']
     bridge_stp false
     mtu 1501
-    pre_up 'pre up code'
+    pre_up ['1st pre up code', '2nd pre up code']
     up 'code for up'
     post_up 'post up it'
     pre_down 'pre down plz'


### PR DESCRIPTION
All of the Debian interface commands support appearing multiple times.
Expose that functionality by accepting an array for the command options.

The RHEL provider also creates execute resource for post-up, which also
accepts an array of commands to run.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
Fixes: https://github.com/target/network_interfaces_v2-cookbook/issues/31