### PR TITLE
Allow interface start without reload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.11.1
+* Add ability to start but not reload interfaces via start & start_type attributes.
+* Add config_file attribute for debian family interface.
+
 # 2.11.0
 * Add ability to define array of pre/up/post and pre/down/post commands.
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Attributes
  * RHEL - true/false if device defined is a VLAN interface
  * Win - Integer VlanID to tag to defined device
 * post_up - Post up command(s) to run after modifying the interface
-* reload (default: true) - Wether or not to reload the device on config changes
+* reload (default: true) - Whether or not to reload the device on config changes
 * reload_type (default: :immediately) - When to reload device on config changes
+* start (default: true) - Whether or not to start the device on config changes (existing devices will not be affected)
+* start_type (default: :immediately) - When to reload device on config changes
 * cookbook (default: 'network_interfaces_v2') - Cookbook to look for template files in
 * source (default: 'ifcfg.erb') - Template file to use for interface config
 
@@ -75,6 +77,7 @@ Attributes
 * down - Down command(s)
 * post_down - Post down command(s)
 * custom - Hash of extra attributes to put in device config
+* config_file - Path to interface definition file
 
 #### RHEL Only Attributes
 * prefix - Netmask length (e.g. 24 for 255.255.255.0)

--- a/libraries/provider_rhel_network_interface.rb
+++ b/libraries/provider_rhel_network_interface.rb
@@ -81,8 +81,16 @@ class Chef
                       defroute: new_resource.defroute,
                       ovsbootproto: new_resource.ovsbootproto,
                       ovsdhcpinterfaces: new_resource.ovsdhcpinterfaces
+            notifies :run, "execute[start interface #{new_resource.device}]", new_resource.start_type if new_resource.start && !new_resource.reload
             notifies :run, "execute[reload interface #{new_resource.device}]", new_resource.reload_type if new_resource.reload
             notifies :run, "execute[post up command for #{new_resource.device}]", :immediately unless new_resource.post_up.nil?
+          end
+
+          execute "start interface #{new_resource.device}" do
+            command <<-EOF
+              ifup #{new_resource.device}
+            EOF
+            action :nothing
           end
 
           execute "reload interface #{new_resource.device}" do

--- a/libraries/provider_win_network_interface.rb
+++ b/libraries/provider_win_network_interface.rb
@@ -130,6 +130,7 @@ class Chef
         # Manage additional updates after interface has been reconfigured
         #
         def post_updates
+          start if new_resource.updated_by_last_action? && new_resource.start && !new_resource.reload
           reload if new_resource.updated_by_last_action? && new_resource.reload
           post_up(new_resource.post_up) unless new_resource.post_up.nil? || !new_resource.updated_by_last_action?
         end
@@ -413,6 +414,12 @@ class Chef
           converge_it("Reloading #{new_resource.device}") do
             adapter.disable
             sleep 5
+            adapter.enable
+          end
+        end
+
+        def start
+          converge_it("Starting #{new_resource.device}") do
             adapter.enable
           end
         end

--- a/libraries/resource_debian_network_interface.rb
+++ b/libraries/resource_debian_network_interface.rb
@@ -39,6 +39,11 @@ class Chef
           @source = 'debian_interface.erb'
           @pre_up = 'sleep 2'
           @ipv6 = false
+          @config_file = "/etc/network/interfaces.d/#{name}"
+        end
+
+        def config_file(arg = nil)
+          set_or_return(:config_file, arg, kind_of: String)
         end
 
         def bridge_ports(arg = nil)

--- a/libraries/resource_network_interface.rb
+++ b/libraries/resource_network_interface.rb
@@ -42,6 +42,8 @@ class Chef
         @source = 'ifcfg.erb'
         @reload = true
         @reload_type = :immediately
+        @start = true
+        @start_type = :immediately
       end
 
       def cookbook(arg = nil)
@@ -106,6 +108,14 @@ class Chef
 
       def reload_type(arg = nil)
         set_or_return(:reload_type, arg, kind_of: Symbol)
+      end
+
+      def start(arg = nil)
+        set_or_return(:start, arg, kind_of: [TrueClass, FalseClass])
+      end
+
+      def start_type(arg = nil)
+        set_or_return(:start_type, arg, kind_of: Symbol)
       end
 
       def hw_address(arg = nil)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Providers for configuring network on Ubuntu, RHEL, and Windows
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/target/network_interfaces_v2-cookbook'
 issues_url       'https://github.com/target/network_interfaces_v2-cookbook/issues'
-version          '2.11.0'
+version          '2.11.1'
 chef_version     '>= 12'
 
 supports 'ubuntu', '>= 14.04'

--- a/spec/libraries/provider_win_network_interface_spec.rb
+++ b/spec/libraries/provider_win_network_interface_spec.rb
@@ -295,12 +295,23 @@ describe Chef::Provider::NetworkInterface::Win do
       provider.action_create
     end
 
-    it 'does not reloads interface if defined by user' do
+    it 'does not start or reload interface if defined by user' do
       allow(adapter_config).to receive(:SetDNSDomain)
       new_resource.dns_domain 'my_dns_domain.com'
-      new_resource.reload false # Defined by user not to reload
+      new_resource.reload false # Defined by user
+      new_resource.start false # Defined by user
       expect(adapter).not_to receive(:disable)
       expect(adapter).not_to receive(:enable)
+      provider.action_create
+    end
+
+    it 'start but do not reload interface if defined by user' do
+      allow(adapter_config).to receive(:SetDNSDomain)
+      new_resource.dns_domain 'my_dns_domain.com'
+      new_resource.reload false # Defined by user
+      new_resource.start true # Defined by user
+      expect(adapter).not_to receive(:disable)
+      expect(adapter).to receive(:enable)
       provider.action_create
     end
 


### PR DESCRIPTION
If an interface runs a bridge, it may be undesirable to have the
interface reloaded at runtime. At the same time, it may be desirable to
start the interface if it's not yet started.

Add start/start_type attributes mirroring reload/reload_type, so that
you can define new interfaces with reload=false, start=true, and have
then started but not reloaded.

As a related cleanup, add a config_file attribute to debian interfaces,
to refactor the repeated path.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>